### PR TITLE
Zach/sort vars formatting

### DIFF
--- a/src/formatting/fol/default.rs
+++ b/src/formatting/fol/default.rs
@@ -196,7 +196,12 @@ impl Display for Format<'_, Quantification> {
             Quantifier::Exists => write!(f, "exists"),
         }?;
 
-        let iter = variables.iter().map(Format);
+        let mut sorted_vars = Vec::<Variable>::new();
+        for var in variables.iter() {
+            sorted_vars.push(var.clone());
+        }
+        sorted_vars.sort();
+        let iter = sorted_vars.iter().map(Format);
         for var in iter {
             write!(f, " {var}")?;
         }
@@ -204,7 +209,6 @@ impl Display for Format<'_, Quantification> {
         Ok(())
     }
 }
-
 impl Display for Format<'_, UnaryConnective> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.0 {
@@ -436,7 +440,7 @@ mod tests {
                 ]
             })
             .to_string(),
-            "forall X Y$i N"
+            "forall N X Y$i"
         );
     }
 

--- a/src/formatting/fol/default.rs
+++ b/src/formatting/fol/default.rs
@@ -95,7 +95,7 @@ impl Display for Format<'_, GeneralTerm> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.0 {
             GeneralTerm::Symbol(s) => write!(f, "{s}"),
-            GeneralTerm::GeneralVariable(v) => write!(f, "{v}$g"),
+            GeneralTerm::GeneralVariable(v) => write!(f, "{v}"),
             GeneralTerm::IntegerTerm(t) => Format(t).fmt(f),
         }
     }
@@ -180,7 +180,7 @@ impl Display for Format<'_, Variable> {
         let sort = &self.0.sort;
 
         match sort {
-            Sort::General => write!(f, "{name}$g"),
+            Sort::General => write!(f, "{name}"),
             Sort::Integer => write!(f, "{name}$i"),
         }
     }
@@ -436,7 +436,7 @@ mod tests {
                 ]
             })
             .to_string(),
-            "forall X$g Y$i N$g"
+            "forall X Y$i N"
         );
     }
 
@@ -466,7 +466,7 @@ mod tests {
                 }]
             }))
             .to_string(),
-            "5 < I$g"
+            "5 < I"
         );
         assert_eq!(Format(&AtomicFormula::Falsity).to_string(), "#false");
     }
@@ -511,7 +511,7 @@ mod tests {
                 .into()
             })
             .to_string(),
-            "forall X$g p(X$g)"
+            "forall X p(X)"
         );
 
         assert_eq!(

--- a/src/syntax_tree/fol.rs
+++ b/src/syntax_tree/fol.rs
@@ -9,6 +9,8 @@ use crate::{
     syntax_tree::{impl_node, Node},
 };
 
+use std::cmp::Ordering;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BasicIntegerTerm {
     Infimum,
@@ -143,6 +145,26 @@ pub struct Variable {
 }
 
 impl_node!(Variable, Format, VariableParser);
+
+impl Ord for Variable {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (&self.name).cmp(&other.name)
+    }
+}
+
+impl PartialOrd for Variable {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let size1 = self.name.clone();
+        let size2 = other.name.clone();
+        if size1 < size2 {
+            Some(Ordering::Less)
+        } else if size1 > size2 {
+            Some(Ordering::Greater)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BinaryConnective {


### PR DESCRIPTION
Implementing an order on variables (alphabetical w.r.t. names) so quantifications are printed the same way even if they were assembled from an unordered set of variables (as is often the case in tau*)