### PR TITLE
Change the minimum supported Rust version to 1.70.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.67.0
+          - 1.70.0
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anthem"
 version = "0.1.0-dev"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 edition = "2021"
 authors = ["Zach Hansen <zachhansen@unomaha.edu>", "Tobias Stolzmann <tobias.stolzmann@gmail.com>"]
 description = "A translator between answer set programs and first-order logic"


### PR DESCRIPTION
This change is done to speed up integration since cargo uses the "sparse" protocol for crates.io by default since this version.