### PR TITLE
Editing ASP grammar to permit _ in object constants and predicate sym…

### DIFF
--- a/src/parsing/asp/grammar.pest
+++ b/src/parsing/asp/grammar.pest
@@ -3,7 +3,7 @@ WHITESPACE = _{ " " | NEWLINE }
 precomputed_term = { infimum | integer | symbol | supremum }
     infimum = @{ "#infimum" | "#inf" }
     integer = @{ "0" | "-"? ~ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
-    symbol = @{ !negation ~ ASCII_ALPHA_LOWER ~ ASCII_ALPHANUMERIC* }
+    symbol = @{ !negation ~ "_"? ~ ASCII_ALPHA_LOWER ~ (ASCII_ALPHANUMERIC | "_")* }
     supremum = @{ "#supremum" | "#sup" }
 
 variable = @{ ASCII_ALPHA_UPPER ~ ASCII_ALPHANUMERIC* }

--- a/src/parsing/asp/pest.rs
+++ b/src/parsing/asp/pest.rs
@@ -475,15 +475,17 @@ mod tests {
                 ("a", PrecomputedTerm::Symbol("a".into())),
                 ("aa", PrecomputedTerm::Symbol("aa".into())),
                 ("aA", PrecomputedTerm::Symbol("aA".into())),
+                ("_a", PrecomputedTerm::Symbol("_a".into())),
+                ("a_", PrecomputedTerm::Symbol("a_".into())),
                 ("noto", PrecomputedTerm::Symbol("noto".into())),
                 ("#sup", PrecomputedTerm::Supremum),
                 ("#supremum", PrecomputedTerm::Supremum),
             ])
             .should_reject([
-                "_a",
                 "'a",
                 "_'x'_'x'_",
                 "A",
+                "_A",
                 "4 2",
                 "00",
                 "-0",
@@ -773,14 +775,30 @@ mod tests {
     #[test]
     fn parse_predicate() {
         PredicateParser
-            .should_parse_into([(
-                "p/1",
-                Predicate {
-                    symbol: "p".into(),
-                    arity: 1,
-                },
-            )])
-            .should_reject(["p", "1/1", "p/00", "p/01", "_/1", "p/p", "_p/1"]);
+            .should_parse_into([
+                (
+                    "p/1",
+                    Predicate {
+                        symbol: "p".into(),
+                        arity: 1,
+                    },
+                ),
+                (
+                    "p_/1",
+                    Predicate {
+                        symbol: "p_".into(),
+                        arity: 1,
+                    },
+                ),
+                (
+                    "_p/1",
+                    Predicate {
+                        symbol: "_p".into(),
+                        arity: 1,
+                    },
+                ),
+            ])
+            .should_reject(["p", "1/1", "p/00", "p/01", "_/1", "p/p"]);
     }
 
     #[test]
@@ -805,6 +823,13 @@ mod tests {
                     "p(1)",
                     Atom {
                         predicate_symbol: "p".into(),
+                        terms: vec![Term::PrecomputedTerm(PrecomputedTerm::Numeral(1))],
+                    },
+                ),
+                (
+                    "sqrt_b(1)",
+                    Atom {
+                        predicate_symbol: "sqrt_b".into(),
                         terms: vec![Term::PrecomputedTerm(PrecomputedTerm::Numeral(1))],
                     },
                 ),


### PR DESCRIPTION
…bols.

The FOL grammar defines symbolic constants as

symbolic_constant = @{ !keyword ~ "_"? ~ ASCII_ALPHA_LOWER ~ (ASCII_ALPHANUMERIC | "_")* }

whereas the ASP grammar (prior to this update) defined them as

symbol = @{ !negation ~ ASCII_ALPHA_LOWER ~ ASCII_ALPHANUMERIC* }

which seems to be an oversight.

Closes #62 