### PR TITLE
Adding support for comments to ASP/FOL grammars

### DIFF
--- a/src/parsing/asp/grammar.pest
+++ b/src/parsing/asp/grammar.pest
@@ -1,5 +1,5 @@
 WHITESPACE = _{ " " | NEWLINE }
-COMMENT = _{ ("%" ~ (!NEWLINE ~ ANY)* ~ NEWLINE) | ("%" ~ (!NEWLINE ~ ANY)* ~ EOI)}
+COMMENT = _{ "%" ~ (!NEWLINE ~ ANY)* ~ (NEWLINE | EOI) }
 
 precomputed_term = { infimum | integer | symbol | supremum }
     infimum = @{ "#infimum" | "#inf" }

--- a/src/parsing/asp/grammar.pest
+++ b/src/parsing/asp/grammar.pest
@@ -1,4 +1,5 @@
 WHITESPACE = _{ " " | NEWLINE }
+COMMENT = _{ ("%" ~ (!NEWLINE ~ ANY)* ~ NEWLINE) | ("%" ~ (!NEWLINE ~ ANY)* ~ EOI)}
 
 precomputed_term = { infimum | integer | symbol | supremum }
     infimum = @{ "#infimum" | "#inf" }

--- a/src/parsing/asp/pest.rs
+++ b/src/parsing/asp/pest.rs
@@ -1091,7 +1091,7 @@ mod tests {
                 },
             ),
             (
-                "a.\n",
+                "% First comment. \na. %%%% Second comment %%%%\n%Last comment",
                 Program {
                     rules: vec![Rule {
                         head: Head::Basic(Atom {

--- a/src/parsing/asp/pest.rs
+++ b/src/parsing/asp/pest.rs
@@ -1091,6 +1091,18 @@ mod tests {
                 },
             ),
             (
+                "a.\n",
+                Program {
+                    rules: vec![Rule {
+                        head: Head::Basic(Atom {
+                            predicate_symbol: "a".into(),
+                            terms: vec![],
+                        }),
+                        body: Body { formulas: vec![] },
+                    }],
+                },
+            ),
+            (
                 "% First comment. \na. %%%% Second comment %%%%\n%Last comment",
                 Program {
                     rules: vec![Rule {

--- a/src/parsing/fol/grammar.pest
+++ b/src/parsing/fol/grammar.pest
@@ -7,6 +7,7 @@
 // can be transformed into TPTP formulas (Vampire-compatible input).
 
 WHITESPACE = _{ " " | NEWLINE }
+COMMENT = _{ ("%" ~ (!NEWLINE ~ ANY)* ~ NEWLINE) | ("%" ~ (!NEWLINE ~ ANY)* ~ EOI)}
 
 keyword = _{ primitive | binary_connective | unary_connective | quantifier }
 

--- a/src/parsing/fol/grammar.pest
+++ b/src/parsing/fol/grammar.pest
@@ -7,7 +7,7 @@
 // can be transformed into TPTP formulas (Vampire-compatible input).
 
 WHITESPACE = _{ " " | NEWLINE }
-COMMENT = _{ ("%" ~ (!NEWLINE ~ ANY)* ~ NEWLINE) | ("%" ~ (!NEWLINE ~ ANY)* ~ EOI)}
+COMMENT = _{ "%" ~ (!NEWLINE ~ ANY)* ~ (NEWLINE | EOI) }
 
 keyword = _{ primitive | binary_connective | unary_connective | quantifier }
 

--- a/src/parsing/fol/pest.rs
+++ b/src/parsing/fol/pest.rs
@@ -1353,6 +1353,15 @@ mod tests {
                     }))],
                 },
             ),
+            (
+                "% First comment. \na. %%%% Second comment %%%%\n%Last comment",
+                Theory {
+                    formulas: vec![Formula::AtomicFormula(AtomicFormula::Atom(Atom {
+                        predicate_symbol: "a".into(),
+                        terms: vec![],
+                    }))],
+                },
+            ),
         ]);
     }
 }


### PR DESCRIPTION
COMMENT = _{ ("%" ~ (!NEWLINE ~ ANY)* ~ NEWLINE) | ("%" ~ (!NEWLINE ~ ANY)* ~ EOI)}

Matches "%" followed by 0 or more of any character except newline followed by a newline or the end of the file. Allows ASP-style comments in both .lp and .spec files., e.g.

%%%% Comment 1 %%%%
p(X) :- q(X).   %%% Comment 2
%%% Comment 3

Closes #63 