### PR TITLE
Format option for translate command

### DIFF
--- a/src/command_line/arguments.rs
+++ b/src/command_line/arguments.rs
@@ -28,6 +28,14 @@ pub enum Command {
         #[arg(long, value_enum)]
         with: Translation,
 
+        /// Output format
+        #[arg(long, value_enum, default_value_t)]
+        format: Format,
+
+        /// Role of output formulas (only used for TPTP output)
+        #[arg(long, value_enum, default_value_t)]
+        role: Role,
+
         /// The file to translate
         input: Option<PathBuf>,
     },
@@ -98,6 +106,20 @@ pub enum Translation {
     Completion,
     Gamma,
     TauStar,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Format {
+    #[default]
+    Default,
+    TPTP,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Role {
+    #[default]
+    Axiom,
+    Conjecture,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/src/command_line/procedures.rs
+++ b/src/command_line/procedures.rs
@@ -93,10 +93,9 @@ pub fn main() -> Result<()> {
                 Translation::Gamma => {
                     let theory =
                         input.map_or_else(fol::Theory::from_stdin, fol::Theory::from_file)?;
-                    let mut transition_axioms = Theory { formulas: vec![] };
-                    for p in theory.prediates() {
-                        transition_axioms.formulas.push(transition(p));
-                    }
+                    let transition_axioms = Theory {
+                        formulas: theory.prediates().into_iter().map(transition).collect(),
+                    };
                     let gamma_theory = gamma(theory);
                     output_theory(gamma_theory, Some(transition_axioms), format, role)
                 }

--- a/src/syntax_tree/fol.rs
+++ b/src/syntax_tree/fol.rs
@@ -876,6 +876,14 @@ pub struct Theory {
 impl_node!(Theory, Format, TheoryParser);
 
 impl Theory {
+    pub fn prediates(&self) -> IndexSet<Predicate> {
+        let mut preds = IndexSet::new();
+        for formula in self {
+            preds.extend(formula.predicates())
+        }
+        preds
+    }
+
     pub fn replace_placeholders(self, mapping: &IndexMap<String, FunctionConstant>) -> Self {
         self.into_iter()
             .map(|f| f.replace_placeholders(mapping))

--- a/src/verifying/task/strong_equivalence.rs
+++ b/src/verifying/task/strong_equivalence.rs
@@ -28,29 +28,30 @@ pub struct StrongEquivalenceTask {
     pub break_equivalences: bool,
 }
 
+pub fn transition(p: fol::Predicate) -> fol::Formula {
+    let hp = gamma::here(p.clone().to_formula());
+    let tp = gamma::there(p.to_formula());
+
+    let variables = hp.free_variables();
+
+    fol::Formula::BinaryFormula {
+        connective: fol::BinaryConnective::Implication,
+        lhs: hp.into(),
+        rhs: tp.into(),
+    }
+    .quantify(fol::Quantifier::Forall, variables.into_iter().collect())
+}
+
 impl StrongEquivalenceTask {
     fn transition_axioms(&self) -> fol::Theory {
-        fn transition(p: asp::Predicate) -> fol::Formula {
-            let p: fol::Predicate = p.into();
-
-            let hp = gamma::here(p.clone().to_formula());
-            let tp = gamma::there(p.to_formula());
-
-            let variables = hp.free_variables();
-
-            fol::Formula::BinaryFormula {
-                connective: fol::BinaryConnective::Implication,
-                lhs: hp.into(),
-                rhs: tp.into(),
-            }
-            .quantify(fol::Quantifier::Forall, variables.into_iter().collect())
-        }
-
         let mut predicates = self.left.predicates();
         predicates.extend(self.right.predicates());
 
         fol::Theory {
-            formulas: predicates.into_iter().map(transition).collect(),
+            formulas: predicates
+                .into_iter()
+                .map(|p| transition(p.into()))
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
Adds a `--format` argument to the translate command with options `default` and `tptp`. The TPTP output also includes the preamble and all the type definitions and so on. For the TPTP output it is also possible to change wich role the formulas are given with the `--role` argument to either `axiom` or `conjecture`.