### PR TITLE
Changes to completion API

### DIFF
--- a/src/translating/completion.rs
+++ b/src/translating/completion.rs
@@ -61,7 +61,7 @@ fn heads(definitions: &Definitions) -> IndexMap<fol::Predicate, Vec<&fol::Atomic
     result
 }
 
-fn components(theory: fol::Theory) -> Option<(Definitions, Constraints)> {
+pub(crate) fn components(theory: fol::Theory) -> Option<(Definitions, Constraints)> {
     let mut definitions: Definitions = IndexMap::new();
     let mut constraints = Vec::new();
 

--- a/src/translating/completion.rs
+++ b/src/translating/completion.rs
@@ -12,10 +12,8 @@ pub fn completion(theory: fol::Theory) -> Option<fol::Theory> {
     let (definitions, constraints) = components(theory)?;
 
     // Confirm there are no head mismatches
-    for (_, heads) in heads(&definitions) {
-        if !heads.iter().all_equal() {
-            return None;
-        }
+    if has_head_mismatches(&definitions) {
+        return None;
     }
 
     // Complete the definitions
@@ -40,6 +38,15 @@ pub fn completion(theory: fol::Theory) -> Option<fol::Theory> {
     formulas.extend(completed_definitions);
 
     Some(fol::Theory { formulas })
+}
+
+pub(crate) fn has_head_mismatches(definitions: &Definitions) -> bool {
+    for (_, heads) in heads(definitions) {
+        if !heads.iter().all_equal() {
+            return true;
+        }
+    }
+    false
 }
 
 fn heads(definitions: &Definitions) -> IndexMap<fol::Predicate, Vec<&fol::AtomicFormula>> {


### PR DESCRIPTION
Both the components function and the check for head mismatches are also needed for the implementation of ordered completion. Therefore, this PR moves the check for head mismatches into a function and makes both this function and the components function ```pub(crate)``` so they can be reused.