### PR TITLE
Modification of simplify

### DIFF
--- a/src/simplifying/fol/ht.rs
+++ b/src/simplifying/fol/ht.rs
@@ -16,16 +16,18 @@ pub fn simplify(theory: Theory) -> Theory {
 }
 
 fn simplify_formula(formula: Formula) -> Formula {
-    formula.apply_all(&mut vec![
-        Box::new(substitute_defined_variables),
-        Box::new(evaluate_comparisons_between_equal_terms),
-        Box::new(remove_identities),
-        Box::new(remove_annihilations),
-        Box::new(remove_idempotences),
-        Box::new(remove_orphaned_variables),
-        Box::new(remove_empty_quantifications),
-        Box::new(join_nested_quantifiers),
-    ])
+    formula
+        .apply(&mut Box::new(substitute_defined_variables))
+        .apply_all(&mut vec![
+            Box::new(substitute_defined_variables),
+            Box::new(evaluate_comparisons_between_equal_terms),
+            Box::new(remove_identities),
+            Box::new(remove_annihilations),
+            Box::new(remove_idempotences),
+            Box::new(remove_orphaned_variables),
+            Box::new(remove_empty_quantifications),
+            Box::new(join_nested_quantifiers),
+        ])
 }
 
 fn substitute_defined_variables(formula: Formula) -> Formula {

--- a/src/simplifying/fol/ht.rs
+++ b/src/simplifying/fol/ht.rs
@@ -379,6 +379,7 @@ mod tests {
             ("forall X a", "a"),
             ("X = X and a", "a"),
             ("forall X (X = X)", "#true"),
+            ("exists X (X = 1)", "#true"),
         ] {
             assert_eq!(
                 simplify_formula(src.parse().unwrap()),

--- a/src/simplifying/fol/ht.rs
+++ b/src/simplifying/fol/ht.rs
@@ -19,7 +19,6 @@ fn simplify_formula(formula: Formula) -> Formula {
     formula
         .apply(&mut Box::new(substitute_defined_variables))
         .apply_all(&mut vec![
-            Box::new(substitute_defined_variables),
             Box::new(evaluate_comparisons_between_equal_terms),
             Box::new(remove_identities),
             Box::new(remove_annihilations),
@@ -382,6 +381,11 @@ mod tests {
             ("X = X and a", "a"),
             ("forall X (X = X)", "#true"),
             ("exists X (X = 1)", "#true"),
+            (
+                "exists X (X = 1 or exists Y (Y = 1 and Y != 1))",
+                "exists X (X = 1)",
+            ),
+            ("exists X (X = 1 or exists Y (Y = 1 and Y != 1))", "#true"),
         ] {
             assert_eq!(
                 simplify_formula(src.parse().unwrap()),


### PR DESCRIPTION
A formula "exists X (X = 1)" should be simplified to "#true" with the currently available simplifications, but using the simplify function this does not happen.

The problem is that the syntax tree is traversed once and the ```substitute_defined_variables``` simplification can only be applied when the root of the tree is reached. Therefore, the evaluate comparisons simplifications will not be applied as the root is not a comparison.

Instead of using a fixpoint algorithm it is sufficient to first apply ```substitute_defined_variables``` to the whole syntax tree and then use ```apply_all``` to apply all the other simplifications.

Of course a fixpoint algorithm is still necessary for more complicated examples (e.g. "exists X (X = 1 or exists Y (Y = 1 and Y != 1))" should simplify to "#true" but with the proposed modification it only simplifies to "#exists X (X = 1)", to reach "#true" it would require a second application of the simplify algorithm). But maybe this could still be useful as an option that:

- simplifies more than just ```apply_all```,
- but only needs one additional traversal of the syntax tree instead of a full fixpoint algorithm.