### PR TITLE
Adding strongly equivalent normalization transformations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ pub mod breaking;
 pub mod command_line;
 pub mod convenience;
 pub mod formatting;
+pub mod normalizing;
 pub mod parsing;
 pub mod simplifying;
 pub mod syntax_tree;

--- a/src/normalizing/asp.rs
+++ b/src/normalizing/asp.rs
@@ -1,0 +1,130 @@
+use {
+    crate::syntax_tree::asp::{
+        Atom, AtomicFormula, BinaryOperator, Body, Comparison, Head, Program, Relation, Rule, Term,
+        Variable,
+    },
+    lazy_static::lazy_static,
+    regex::Regex,
+};
+
+lazy_static! {
+    static ref RE: Regex = Regex::new(r"^V(?<number>[0-9]*)$").unwrap();
+}
+
+/// Taken from tau-star.rs
+/// Choose fresh variants of `Vn` by incrementing `n`
+fn choose_fresh_global_variables(program: &Program) -> Vec<Variable> {
+    let mut max_arity = 0;
+    let mut head_arity;
+    for rule in program.rules.iter() {
+        head_arity = rule.head.arity();
+        if head_arity > max_arity {
+            max_arity = head_arity;
+        }
+    }
+    let mut max_taken_var = 0;
+    let taken_vars = program.variables();
+    for var in taken_vars {
+        if let Some(caps) = RE.captures(&var.0) {
+            let taken: usize = (caps["number"]).parse().unwrap_or(0);
+            if taken > max_taken_var {
+                max_taken_var = taken;
+            }
+        }
+    }
+    let mut globals = Vec::<Variable>::new();
+    for i in 1..max_arity + 1 {
+        let mut v: String = "V".to_owned();
+        let counter: &str = &(max_taken_var + i).to_string();
+        v.push_str(counter);
+        globals.push(Variable(v));
+    }
+    globals
+}
+
+// fn replace_intervals_in_term_shallow<I>(term: Term, gvars: I) -> (Term, Vec<AtomicFormula>)
+//     where I: Iterator
+// {
+
+//     todo!()
+// }
+
+pub fn remove_intervals_in_head(rule: Rule) -> Rule {
+    let program = Program {
+        rules: vec![rule.clone()],
+    };
+    let mut fresh_gvars = choose_fresh_global_variables(&program).into_iter();
+
+    let mut rule_copy = rule.clone();
+
+    match rule.head {
+        Head::Basic(atom) | Head::Choice(atom) => {
+            let mut new_terms = vec![];
+            let mut interval_formulas = vec![];
+            for term in atom.terms {
+                match term {
+                    Term::BinaryOperation {
+                        op: BinaryOperator::Interval,
+                        ..
+                    } => {
+                        let v = Term::Variable(fresh_gvars.next().unwrap().clone());
+                        let f = AtomicFormula::Comparison(Comparison {
+                            relation: Relation::Equal,
+                            lhs: v.clone(),
+                            rhs: term,
+                        });
+                        new_terms.push(v);
+                        interval_formulas.push(f);
+                    }
+                    _ => {
+                        new_terms.push(term);
+                    }
+                }
+            }
+
+            let new_atom = Atom {
+                predicate_symbol: atom.predicate_symbol,
+                terms: new_terms,
+            };
+            let new_head = match &rule_copy.head {
+                &Head::Basic(_) => Head::Basic(new_atom),
+                &Head::Choice(_) => Head::Choice(new_atom),
+                &Head::Falsity => unreachable!(),
+            };
+
+            interval_formulas.append(&mut rule_copy.body.formulas);
+            let new_body = Body {
+                formulas: interval_formulas,
+            };
+
+            Rule {
+                head: new_head,
+                body: new_body,
+            }
+        }
+        Head::Falsity => rule,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::remove_intervals_in_head, crate::syntax_tree::asp::Rule};
+
+    #[test]
+    fn remove() {
+        for (src, target) in [
+            (
+                "q(1..X, 1..Y) :- p(X,Y,Z).",
+                "q(V1, V2) :- V1 = 1..X, V2 = 1..Y, p(X,Y,Z).",
+            ),
+            // ("p(2*(1..8)).", "p(2*V1) :- V1 = 1..8."),
+        ] {
+            let left = remove_intervals_in_head(src.parse::<Rule>().unwrap());
+            let right = target.parse::<Rule>().unwrap();
+            assert!(
+                left == right,
+                "assertion `left == right` failed:\n left:\n{left}\n right:\n{right}"
+            );
+        }
+    }
+}

--- a/src/normalizing/asp.rs
+++ b/src/normalizing/asp.rs
@@ -86,10 +86,10 @@ pub fn remove_intervals_in_head(rule: Rule) -> Rule {
                 predicate_symbol: atom.predicate_symbol,
                 terms: new_terms,
             };
-            let new_head = match &rule_copy.head {
-                &Head::Basic(_) => Head::Basic(new_atom),
-                &Head::Choice(_) => Head::Choice(new_atom),
-                &Head::Falsity => unreachable!(),
+            let new_head = match rule_copy.head {
+                Head::Basic(_) => Head::Basic(new_atom),
+                Head::Choice(_) => Head::Choice(new_atom),
+                Head::Falsity => unreachable!(),
             };
 
             interval_formulas.append(&mut rule_copy.body.formulas);

--- a/src/normalizing/mod.rs
+++ b/src/normalizing/mod.rs
@@ -1,0 +1,1 @@
+pub mod asp;


### PR DESCRIPTION
Natural translation does not produce completable theories, and thus cannot be directly integrated with the existing implementation of completion. The paper "On Program Completion, with an Application to the Sum and Product Puzzle" describes a more restrictive class of regular rules that forbids intervals in the heads of rules. It also describes a transformation, NCOMP, which parallels program completion for rules in this class.

Natural translation nu (as defined in "Transforming Gringo Rules into Formulas in a Natural Way") can be defined as a translation option for anthem, however, external equivalence in anthem should follow the description of NCOMP and its corresponding restricted version of nu.

However, we can obtain rules in this restricted class from many regular rules via strongly equivalent transformations on programs (as suggested by "On Program Completion", section 6). This is one example of a feature we have discussed in the past, which is the ability to reduce an ASP program to a strongly equivalent mini-gringo program of a simpler form. Here I called this process "normalization" and provided an example of one such function that is relevant to nu and NCOMP. A recursive extension of this function is needed to pass the commented-out test case. 