### PR TITLE
Fix link to anthem manual in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 It operates by translating answer set programs written in the mini-gringo dialect of [clingo](https://potassco.org/clingo/) into many-sorted first-order theories.
 Using automated theorem provers, `anthem` can then verify properties of the original programs, such as strong and external equivalence.
 
-Check out the [Manual](https://potassco.org/anthem/) to learn how to install and use `anthem`.
+Check out the [Manual](https://docs.potassco.org/anthem/) to learn how to install and use `anthem`.
 
 If you want to use `anthem` as a library to build your own application, you can do so.
 Check out the [API documentation](https://docs.rs/anthem/) for the available functionalities.


### PR DESCRIPTION
Updated the link to the anthem manual in the README.